### PR TITLE
Double fork for unshare

### DIFF
--- a/pocket/core/create.py
+++ b/pocket/core/create.py
@@ -15,37 +15,43 @@ def create(config_path):
     config = Config(config_path)
     base_image = config.args['image']
     container_id = str(uuid.uuid4())
+
     console.log('creating a new container (%s)' % container_id)
 
-    unshare.unshare(unshare.CLONE_NEWUTS | unshare.CLONE_NEWNS | unshare.CLONE_NEWPID)
+    # setup the cgroup
+    cg = cgroups.Cgroup(container_id)
+    if 'limit' in config.args.keys():
+        if 'cpu' in config.args['limit'].keys():
+            cg.set_cpu_limit(config.args['limit']['cpu'])
+        if 'mem' in config.args['limit'].keys():
+            cg.set_memory_limit(config.args['limit']['mem'])
+
+    console.log('Spinning up a filesystem...')
+    fs.setup_fs(base_image, container_id)
+
+    for item in config.args.get('copy', []):
+        console.log(f'{container_id}: copying {item["src"]} to {item["dest"]}')
+        fs.copy_to_container(item['src'], item['dest'], container_id)
+
 
     pid = os.fork()
     if pid == 0:
         # container process
-        console.log('Spinning up a filesystem...')
-        fs.setup_fs(base_image, container_id)
-
-        # set up the cgroup
-        cg = cgroups.Cgroup(container_id)
-        if 'limit' in config.args.keys():
-            if 'cpu' in config.args['limit'].keys():
-                cg.set_cpu_limit(config.args['limit']['cpu'])
-            if 'mem' in config.args['limit'].keys():
-                cg.set_memory_limit(config.args['limit']['mem'])
-
+        console.log('Pocket starting with process-id: %d' % os.getpid())
         cg.add(os.getpid())
-
-        for item in config.args.get('copy', []):
-            console.log(f'{container_id}: copying {item["src"]} to {item["dest"]}')
-            fs.copy_to_container(item['src'], item['dest'], container_id)
 
         os.system(f'hostname {container_id}')
         os.chroot(fs.get_path_to_container(container_id))
         os.chdir('/')
 
-        for item in config.args.get('run', []):
-            console.log(f'{container_id}: executing - {item}')
-            os.execve(item.split(" ")[0], item.split(" "), config.args.get('env', {}))
+        unshare.unshare(unshare.CLONE_NEWUTS | unshare.CLONE_NEWNS | unshare.CLONE_NEWPID)
+        pid2 = os.fork()
+        if pid2 == 0:
+            for item in config.args.get('run', []):
+                console.log(f'{container_id}: executing - {item}')
+                os.execve(item.split(" ")[0], item.split(" "), config.args.get('env', {}))
+        else:
+            os.waitpid(pid2, 0)
     else:
         _, status = os.waitpid(pid, 0)
         console.log(f'Pocket pid: {pid} exited with status {status}')


### PR DESCRIPTION
Unshare is a tricky operation. Unshare(1) and Unshare(2) behave differently. Was facing this problem initially - [unshare-pid-bin-bash-fork-cannot-allocate-memory](https://stackoverflow.com/questions/44666700/unshare-pid-bin-bash-fork-cannot-allocate-memory).

Solution? To emulate the -f flag, I essentially forked the process myself after using Unshare(2). 